### PR TITLE
domain layer for saving rss

### DIFF
--- a/app/src/main/java/com/joelgh/features/rss_management/domain/Rss.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/domain/Rss.kt
@@ -1,0 +1,3 @@
+package com.joelgh.features.rss_management.domain
+
+data class Rss(val name: String, val url: String)

--- a/app/src/main/java/com/joelgh/features/rss_management/domain/RssRepository.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/domain/RssRepository.kt
@@ -1,0 +1,6 @@
+package com.joelgh.features.rss_management.domain
+
+interface RssRepository {
+    fun create(rss: Rss)
+    fun delete(rss: Rss)
+}

--- a/app/src/main/java/com/joelgh/features/rss_management/domain/RssRepository.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/domain/RssRepository.kt
@@ -2,5 +2,4 @@ package com.joelgh.features.rss_management.domain
 
 interface RssRepository {
     fun create(rss: Rss)
-    fun delete(rss: Rss)
 }

--- a/app/src/main/java/com/joelgh/features/rss_management/domain/SaveRssUseCase.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/domain/SaveRssUseCase.kt
@@ -1,0 +1,9 @@
+package com.joelgh.features.rss_management.domain
+
+class SaveRssUseCase(private val repository: RssRepository) {
+
+    fun execute(name: String, url: String){
+        repository.create(Rss(name, url))
+    }
+
+}


### PR DESCRIPTION
## Description de la tarea

Crear la capa de dominio para la funcionalidad guardar rss
#2 
## ¿Cómo se ha implementado?

La interfaz del repositorio tiene el método create para la funcionalidad implementada y el método delete para no tener que modificar la interfaz cuando implemente la funcionalidad para eliminar los rss creados. Por esa misma razón el modelo lo he creado en domain en lugar de dentro del caso de uso.
El nombre y la url del rss los paso como parámetros del método execute porque al construir el viewmodel más adelante necesitará el caso de uso y no tendría sentido que esos datos se conozcan antes de llamar al caso de uso.

## Keywords

Capa de dominio, repositorio, interfaz, caso de uso, modelo de dominio

## Screenshots or Video

<!-- Captura de pantalla de la consola -->

## Objetivos

<!-- Buscar en el README el Resultado de Aprendizaje con el que se está trabajando -->

## Criterios de Evaluación
<!-- 
    Buscar en el README los criterios de Evaluación con los que se están trabajando.
    Marca con una [X] los conseguidos. Ejemplo:
    [ ] Criterio Evaluación 1.
    [ ] Criterio Evaluación 2.
    [X] Criterio Evaluación 3.
-->