### PR TITLE
Get rss use case

### DIFF
--- a/app/src/main/java/com/joelgh/features/rss_management/domain/GetRssUseCase.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/domain/GetRssUseCase.kt
@@ -1,0 +1,9 @@
+package com.joelgh.features.rss_management.domain
+
+import com.joelgh.app.commons.error_management.Either
+import com.joelgh.app.commons.error_management.ErrorApp
+
+class GetRssUseCase(private val repository: RssRepository) {
+
+    suspend fun execute(): Either<ErrorApp, List<Rss>> = repository.getAll()
+}


### PR DESCRIPTION
## Description de la tarea

Crear caso de uso para recuperar rss

## ¿Cómo se ha implementado?

Como el método del repositorio ya se implemento en un issue anterior solo ha sido implementado el caso de uso.
El caso de uso devuelve un either para en caso de que no haya rss guardados no se muestre una pantalla en blanco al usuario sin informarle.

## Keywords

domain, use case, repository

## Screenshots or Video

![Prueba_get_rss](https://user-images.githubusercontent.com/107778199/204881885-a69921fc-91f7-4fe2-a526-bfbbcd842767.png)

## Objetivos

<!-- Buscar en el README el Resultado de Aprendizaje con el que se está trabajando -->

## Criterios de Evaluación
<!-- 
    Buscar en el README los criterios de Evaluación con los que se están trabajando.
    Marca con una [X] los conseguidos. Ejemplo:
    [ ] Criterio Evaluación 1.
    [ ] Criterio Evaluación 2.
    [X] Criterio Evaluación 3.
-->