### PR TITLE
Issue8 rss list view

### DIFF
--- a/app/src/main/java/com/joelgh/app/commons/Extensions.kt
+++ b/app/src/main/java/com/joelgh/app/commons/Extensions.kt
@@ -1,0 +1,13 @@
+package com.joelgh.app.commons
+
+import androidx.fragment.app.Fragment
+import com.google.android.material.snackbar.Snackbar
+import com.joelgh.rss_aggregator.R
+
+fun Fragment.showErrorSnackBar(){
+    Snackbar.make(
+        requireView(),
+        R.string.generic_error,
+        Snackbar.LENGTH_SHORT
+    ).show()
+}

--- a/app/src/main/java/com/joelgh/features/rss_management/presentation/ManagementFactory.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/presentation/ManagementFactory.kt
@@ -6,6 +6,7 @@ import com.joelgh.features.rss_feed.presentation.RssFeedFragmentDirections
 import com.joelgh.features.rss_management.data.RssDataRepository
 import com.joelgh.features.rss_management.data.local.LocalDataSource
 import com.joelgh.features.rss_management.data.local.XmlLocalDataSource
+import com.joelgh.features.rss_management.domain.GetRssUseCase
 import com.joelgh.features.rss_management.domain.RssRepository
 import com.joelgh.features.rss_management.domain.SaveRssUseCase
 
@@ -13,6 +14,10 @@ class ManagementFactory {
     companion object{
         fun getAddRssViewModel(context: Context): AddRssFormViewModel{
             return AddRssFormViewModel(SaveRssUseCase(getRssRepository(context)))
+        }
+
+        fun getRssManagementViewModel(context: Context): RssManagementViewModel{
+            return RssManagementViewModel(GetRssUseCase(getRssRepository(context)))
         }
 
         private fun getRssRepository(context: Context): RssRepository{

--- a/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementFragment.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementFragment.kt
@@ -5,10 +5,12 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.LinearLayout
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModel
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.snackbar.Snackbar
 import com.joelgh.app.commons.GsonSerializer
 import com.joelgh.app.commons.error_management.Either
@@ -23,7 +25,7 @@ import com.joelgh.rss_aggregator.databinding.FragmentRssManagementBinding
 class RssManagementFragment : Fragment() {
     private var binding: FragmentRssManagementBinding? = null
     private var viewModel: RssManagementViewModel? = null
-    private val adapater = RssManagementAdapter()
+    private val rssAdapter = RssManagementAdapter()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -35,13 +37,21 @@ class RssManagementFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         binding = FragmentRssManagementBinding.inflate(inflater, container, false)
-        setUpToolBar()
+        setUpView()
         viewModel = ManagementFactory.getRssManagementViewModel(requireContext())
         return binding?.root
     }
 
-    private fun setUpToolBar(){
+    private fun setUpView(){
         binding?.apply {
+            rssManagementRecycler.apply {
+                adapter = rssAdapter
+                layoutManager = LinearLayoutManager(
+                    requireContext(),
+                    LinearLayoutManager.VERTICAL,
+                    false
+                )
+            }
             rssManagementToolBar.inflateMenu(R.menu.management_tool_bar_menu)
             rssManagementToolBar.setOnMenuItemClickListener{
                 when(it.itemId){
@@ -59,6 +69,7 @@ class RssManagementFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setUpObserver()
+        viewModel?.getRss()
     }
 
     private fun setUpObserver(){
@@ -66,7 +77,7 @@ class RssManagementFragment : Fragment() {
             if(it.isLoading){
                 //Codigo de pantalla de carga
             }else{
-                adapater.setDataItems(it.rssList)
+                rssAdapter.setDataItems(it.rssList)
             }
         }
 

--- a/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementFragment.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementFragment.kt
@@ -78,11 +78,10 @@ class RssManagementFragment : Fragment() {
             if(it.isLoading){
                 //Codigo de pantalla de carga
             }else{
-                if(it.error == null){
-                    rssAdapter.setDataItems(it.rssList)
+                if(it.error != null){
+                    showErrorSnackBar()
                 }else{
                     rssAdapter.setDataItems(it.rssList)
-                    showErrorSnackBar()
                 }
             }
         }

--- a/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementFragment.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementFragment.kt
@@ -14,6 +14,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.snackbar.Snackbar
 import com.joelgh.app.commons.GsonSerializer
 import com.joelgh.app.commons.error_management.Either
+import com.joelgh.app.commons.showErrorSnackBar
 import com.joelgh.features.rss_management.data.RssDataRepository
 import com.joelgh.features.rss_management.data.local.XmlLocalDataSource
 import com.joelgh.features.rss_management.domain.SaveRssUseCase
@@ -77,7 +78,12 @@ class RssManagementFragment : Fragment() {
             if(it.isLoading){
                 //Codigo de pantalla de carga
             }else{
-                rssAdapter.setDataItems(it.rssList)
+                if(it.error == null){
+                    rssAdapter.setDataItems(it.rssList)
+                }else{
+                    rssAdapter.setDataItems(it.rssList)
+                    showErrorSnackBar()
+                }
             }
         }
 

--- a/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementFragment.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementFragment.kt
@@ -20,9 +20,7 @@ import com.joelgh.rss_aggregator.databinding.FragmentRssManagementBinding
 
 class RssManagementFragment : Fragment() {
     private var binding: FragmentRssManagementBinding? = null
-
-    private var name: String? = null
-    private var url: String? = null
+    private var viewModel: RssManagementViewModel? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -35,6 +33,7 @@ class RssManagementFragment : Fragment() {
     ): View? {
         binding = FragmentRssManagementBinding.inflate(inflater, container, false)
         setUpToolBar()
+        viewModel = ManagementFactory.getRssManagementViewModel(requireContext())
         return binding?.root
     }
 
@@ -52,6 +51,23 @@ class RssManagementFragment : Fragment() {
 
     private fun showForm(){
         findNavController().navigate(NavGraphDirections.actionFormData())
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setUpObserver()
+    }
+
+    private fun setUpObserver(){
+        val suscriber = Observer<RssManagementViewModel.UiState>{
+            if(it.isLoading){
+                //Codigo de pantalla de carga
+            }else{
+                //Gestion del either
+            }
+        }
+
+        viewModel?.rssPublisher?.observe(viewLifecycleOwner, suscriber)
     }
 
 }

--- a/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementFragment.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementFragment.kt
@@ -11,9 +11,11 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.snackbar.Snackbar
 import com.joelgh.app.commons.GsonSerializer
+import com.joelgh.app.commons.error_management.Either
 import com.joelgh.features.rss_management.data.RssDataRepository
 import com.joelgh.features.rss_management.data.local.XmlLocalDataSource
 import com.joelgh.features.rss_management.domain.SaveRssUseCase
+import com.joelgh.features.rss_management.presentation.adapter.RssManagementAdapter
 import com.joelgh.rss_aggregator.NavGraphDirections
 import com.joelgh.rss_aggregator.R
 import com.joelgh.rss_aggregator.databinding.FragmentRssManagementBinding
@@ -21,6 +23,7 @@ import com.joelgh.rss_aggregator.databinding.FragmentRssManagementBinding
 class RssManagementFragment : Fragment() {
     private var binding: FragmentRssManagementBinding? = null
     private var viewModel: RssManagementViewModel? = null
+    private val adapater = RssManagementAdapter()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -63,7 +66,7 @@ class RssManagementFragment : Fragment() {
             if(it.isLoading){
                 //Codigo de pantalla de carga
             }else{
-                //Gestion del either
+                adapater.setDataItems(it.rssList)
             }
         }
 

--- a/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementViewModel.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementViewModel.kt
@@ -26,7 +26,7 @@ class RssManagementViewModel(private val getRss: GetRssUseCase) : ViewModel(){
                     UiState(false, rss.value)
                 )
                 is Either.Right -> rssPublisher.postValue(
-                    UiState(false, rssList = rss.value)
+                    UiState(false, null, rss.value)
                 )
             }
         }

--- a/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementViewModel.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementViewModel.kt
@@ -1,0 +1,32 @@
+package com.joelgh.features.rss_management.presentation
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.joelgh.app.commons.error_management.Either
+import com.joelgh.app.commons.error_management.ErrorApp
+import com.joelgh.app.commons.error_management.left
+import com.joelgh.features.rss_management.domain.GetRssUseCase
+import com.joelgh.features.rss_management.domain.Rss
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class RssManagementViewModel(private val getRss: GetRssUseCase) : ViewModel(){
+
+    val rssPublisher: MutableLiveData<UiState> by lazy {
+        MutableLiveData<UiState>()
+    }
+
+    fun getRss() {
+        rssPublisher.value = UiState(true)
+        viewModelScope.launch(Dispatchers.IO) {
+            val rss = getRss.execute()
+            rssPublisher.postValue(UiState(false, rss))
+        }
+    }
+
+    data class UiState(
+        val isLoading: Boolean,
+        val rssList: Either<ErrorApp, List<Rss>> = ErrorApp.DataError().left()
+    )
+}

--- a/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementViewModel.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementViewModel.kt
@@ -21,12 +21,20 @@ class RssManagementViewModel(private val getRss: GetRssUseCase) : ViewModel(){
         rssPublisher.value = UiState(true)
         viewModelScope.launch(Dispatchers.IO) {
             val rss = getRss.execute()
-            rssPublisher.postValue(UiState(false, rss))
+            when(rss){
+                is Either.Left -> rssPublisher.postValue(
+                    UiState(false, rss.value)
+                )
+                is Either.Right -> rssPublisher.postValue(
+                    UiState(false, rssList = rss.value)
+                )
+            }
         }
     }
 
     data class UiState(
         val isLoading: Boolean,
-        val rssList: Either<ErrorApp, List<Rss>> = ErrorApp.DataError().left()
+        val error: ErrorApp? = null,
+        val rssList: List<Rss> = emptyList()
     )
 }

--- a/app/src/main/java/com/joelgh/features/rss_management/presentation/adapter/RssManagementAdapter.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/presentation/adapter/RssManagementAdapter.kt
@@ -1,0 +1,30 @@
+package com.joelgh.features.rss_management.presentation.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.joelgh.features.rss_management.domain.Rss
+import com.joelgh.rss_aggregator.R
+
+class RssManagementAdapter : RecyclerView.Adapter<RssManagementViewHolder>() {
+
+    private val dataItems = mutableListOf<Rss>()
+
+    fun setDataItems(rssList: List<Rss>) {
+        dataItems.clear()
+        dataItems.addAll(rssList)
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RssManagementViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.view_item_rss_management, parent, false)
+        return RssManagementViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: RssManagementViewHolder, position: Int) {
+        holder.bind(dataItems[position])
+    }
+
+    override fun getItemCount(): Int = dataItems.size
+}

--- a/app/src/main/java/com/joelgh/features/rss_management/presentation/adapter/RssManagementViewHolder.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/presentation/adapter/RssManagementViewHolder.kt
@@ -1,0 +1,17 @@
+package com.joelgh.features.rss_management.presentation.adapter
+
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+import com.joelgh.features.rss_management.domain.Rss
+import com.joelgh.rss_aggregator.databinding.ViewItemRssManagementBinding
+
+class RssManagementViewHolder(private val view: View) : RecyclerView.ViewHolder(view) {
+
+    fun bind(rss: Rss){
+        val binding = ViewItemRssManagementBinding.bind(view)
+        binding.apply {
+            rssName.text = rss.name
+            rssUrl.text = rss.url
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_delete.xml
+++ b/app/src/main/res/drawable/ic_delete.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M13.05,42q-1.2,0 -2.1,-0.9 -0.9,-0.9 -0.9,-2.1L10.05,10.5L8,10.5v-3h9.4L17.4,6h13.2v1.5L40,7.5v3h-2.05L37.95,39q0,1.2 -0.9,2.1 -0.9,0.9 -2.1,0.9ZM18.35,34.7h3L21.35,14.75h-3ZM26.65,34.7h3L29.65,14.75h-3Z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_rss_management.xml
+++ b/app/src/main/res/layout/fragment_rss_management.xml
@@ -16,4 +16,11 @@
         style="@style/DefaultBackground"
         android:theme="@style/Theme.RSSaggregator"/>
 
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rss_management_recycler"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/rss_management_tool_bar"
+        app:layout_constraintStart_toStartOf="parent"/>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_rss_management.xml
+++ b/app/src/main/res/layout/fragment_rss_management.xml
@@ -8,8 +8,9 @@
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/rss_management_tool_bar"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="?actionBarSize"
         app:titleTextColor="?colorOnPrimary"
         app:title="@string/rss_management_fragment"
@@ -18,9 +19,11 @@
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rss_management_recycler"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         app:layout_constraintTop_toBottomOf="@id/rss_management_tool_bar"
-        app:layout_constraintStart_toStartOf="parent"/>
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/view_item_rss_management.xml
+++ b/app/src/main/res/layout/view_item_rss_management.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <TextView
+        android:id="@+id/rss_name"
+        tools:text="Nombre del rss"
+        android:textColor="@color/black"
+        android:layout_margin="@dimen/default_spacing"
+        android:textSize="@dimen/title_text_size"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+
+    <TextView
+        android:id="@+id/rss_url"
+        tools:text="Url del rss"
+        android:textColor="@color/black"
+        android:layout_margin="@dimen/default_spacing"
+        android:textSize="@dimen/default_text_size"
+        app:layout_constraintStart_toStartOf="@id/rss_name"
+        app:layout_constraintTop_toBottomOf="@id/rss_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/rss_delete_ic"
+        app:srcCompat="@drawable/ic_delete"
+        android:layout_margin="@dimen/default_spacing"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/rss_name"
+        app:layout_constraintBottom_toBottomOf="@id/rss_url"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="title_text_size">20sp</dimen>
+    <dimen name="default_text_size">14sp</dimen>
+    <dimen name="default_spacing">5dp</dimen>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,5 +8,5 @@
     <string name="form_save">Save</string>
     <string name="save_error">Se ha producido un error al guardar el rss</string>
     <string name="save_success">Se ha guardado correctamente</string>
-    <string name="get_rss_error">No se han podido recuperar los rss</string>
+    <string name="generic_error">Se ha producido un error</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,5 @@
     <string name="form_save">Save</string>
     <string name="save_error">Se ha producido un error al guardar el rss</string>
     <string name="save_success">Se ha guardado correctamente</string>
+    <string name="get_rss_error">No se han podido recuperar los rss</string>
 </resources>


### PR DESCRIPTION
## Description de la tarea

<!-- Descripción sobre lo que se pide en la tarea -->

## ¿Cómo se ha implementado?

He creado una función de extensión para mostrar el snackbar de error, en futuras pr esta implementación será desechada por otra más genérica.
He sustituido la función setUpToolBar por setUpView para añadir el recycler view además de añadir el menú de la tool bar.
El view model gestiona el either que retorna el caso de uso y crea un UiState en función de su contenido, en caso de error muestra una pantalla en blanco y una snackbar informando de que se produjo un error.
En caso de que no haya error se pinta la lista de los rss sin mostrar ninguna snackbar.
Considero esta implementación la mas adecuada ya que el único error contemplado es que no se haya añadido ningún rss antes de mostrar el fragment.

## Keywords

recycler view, presentation, adapter, viewmodel, view holder

## Screenshots or Video

![prueba_rss_manage](https://user-images.githubusercontent.com/107778199/204884483-64b914c0-7caa-4230-8c4e-c62058a41135.png)

## Objetivos

<!-- Buscar en el README el Resultado de Aprendizaje con el que se está trabajando -->

## Criterios de Evaluación
<!-- 
    Buscar en el README los criterios de Evaluación con los que se están trabajando.
    Marca con una [X] los conseguidos. Ejemplo:
    [ ] Criterio Evaluación 1.
    [ ] Criterio Evaluación 2.
    [X] Criterio Evaluación 3.
-->