### PR TITLE
Issue10 presentation delete rss

### DIFF
--- a/app/src/main/java/com/joelgh/app/commons/Extensions.kt
+++ b/app/src/main/java/com/joelgh/app/commons/Extensions.kt
@@ -2,12 +2,11 @@ package com.joelgh.app.commons
 
 import androidx.fragment.app.Fragment
 import com.google.android.material.snackbar.Snackbar
-import com.joelgh.rss_aggregator.R
 
-fun Fragment.showErrorSnackBar(){
+fun Fragment.showErrorSnackBar(text: String){
     Snackbar.make(
         requireView(),
-        R.string.generic_error,
+        text,
         Snackbar.LENGTH_SHORT
     ).show()
 }

--- a/app/src/main/java/com/joelgh/app/commons/Extensions.kt
+++ b/app/src/main/java/com/joelgh/app/commons/Extensions.kt
@@ -3,7 +3,7 @@ package com.joelgh.app.commons
 import androidx.fragment.app.Fragment
 import com.google.android.material.snackbar.Snackbar
 
-fun Fragment.showErrorSnackBar(text: String){
+fun Fragment.showSnackBar(text: String){
     Snackbar.make(
         requireView(),
         text,

--- a/app/src/main/java/com/joelgh/app/commons/error_management/ErrorApp.kt
+++ b/app/src/main/java/com/joelgh/app/commons/error_management/ErrorApp.kt
@@ -2,5 +2,4 @@ package com.joelgh.app.commons.error_management
 
 sealed class ErrorApp {
     class DataError() : ErrorApp()
-    class DeleteError(): ErrorApp()
 }

--- a/app/src/main/java/com/joelgh/app/commons/error_management/ErrorApp.kt
+++ b/app/src/main/java/com/joelgh/app/commons/error_management/ErrorApp.kt
@@ -2,4 +2,5 @@ package com.joelgh.app.commons.error_management
 
 sealed class ErrorApp {
     class DataError() : ErrorApp()
+    class DeleteError(): ErrorApp()
 }

--- a/app/src/main/java/com/joelgh/features/rss_management/presentation/AddRssFormBottomSheet.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/presentation/AddRssFormBottomSheet.kt
@@ -37,7 +37,6 @@ class AddRssFormBottomSheet : BottomSheetDialogFragment() {
             saveRssButton.setOnClickListener{
                 viewModel?.saveRss(rssInputName.text.toString(), rssInputUrl.text.toString())
                 findNavController().navigateUp()
-                showSnackBar(true)
             }
             cancelRssButton.setOnClickListener{
                 findNavController().navigateUp()

--- a/app/src/main/java/com/joelgh/features/rss_management/presentation/ManagementFactory.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/presentation/ManagementFactory.kt
@@ -6,6 +6,7 @@ import com.joelgh.features.rss_feed.presentation.RssFeedFragmentDirections
 import com.joelgh.features.rss_management.data.RssDataRepository
 import com.joelgh.features.rss_management.data.local.LocalDataSource
 import com.joelgh.features.rss_management.data.local.XmlLocalDataSource
+import com.joelgh.features.rss_management.domain.DeleteRssUseCase
 import com.joelgh.features.rss_management.domain.GetRssUseCase
 import com.joelgh.features.rss_management.domain.RssRepository
 import com.joelgh.features.rss_management.domain.SaveRssUseCase
@@ -17,7 +18,8 @@ class ManagementFactory {
         }
 
         fun getRssManagementViewModel(context: Context): RssManagementViewModel{
-            return RssManagementViewModel(GetRssUseCase(getRssRepository(context)))
+            return RssManagementViewModel(GetRssUseCase(getRssRepository(context)),
+                DeleteRssUseCase(getRssRepository(context)))
         }
 
         private fun getRssRepository(context: Context): RssRepository{

--- a/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementFragment.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementFragment.kt
@@ -80,9 +80,15 @@ class RssManagementFragment : Fragment() {
             }else{
                 if(it.error == null){
                     rssAdapter.setDataItems(it.rssList)
+                    rssAdapter.setOnClickItem {
+                        viewModel?.deleteRss(it)
+                    }
                 }else{
                     rssAdapter.setDataItems(it.rssList)
-                    showErrorSnackBar()
+                    rssAdapter.setOnClickItem {
+                        viewModel?.deleteRss(it)
+                    }
+                    showErrorSnackBar(getString(R.string.generic_error))
                 }
             }
         }

--- a/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementFragment.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementFragment.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.joelgh.app.commons.error_management.ErrorApp
 import com.joelgh.app.commons.showSnackBar
 import com.joelgh.features.rss_management.presentation.adapter.RssManagementAdapter
 import com.joelgh.rss_aggregator.NavGraphDirections
@@ -70,16 +71,20 @@ class RssManagementFragment : Fragment() {
                 //Codigo de pantalla de carga
             }else{
                 if(it.error == null){
-                    rssAdapter.setDataItems(it.rssList)
+                    rssAdapter.setDataItems(it.rssList!!)
                     rssAdapter.setOnClickItem {
                         viewModel?.deleteRss(it)
                     }
+                    if(it.deleteSuccess)showSnackBar(getString(R.string.delete_success))
                 }else{
-                    rssAdapter.setDataItems(it.rssList)
+                    rssAdapter.setDataItems(it.rssList!!)
                     rssAdapter.setOnClickItem {
                         viewModel?.deleteRss(it)
                     }
-                    showSnackBar(getString(R.string.generic_error))
+                    when(it.error){
+                        is ErrorApp.DataError -> showSnackBar(getString(R.string.no_rss_found))
+                        is ErrorApp.DeleteError -> showSnackBar(getString(R.string.delete_error))
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementFragment.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementFragment.kt
@@ -5,19 +5,10 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.LinearLayout
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModel
 import androidx.navigation.fragment.findNavController
-import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.google.android.material.snackbar.Snackbar
-import com.joelgh.app.commons.GsonSerializer
-import com.joelgh.app.commons.error_management.Either
-import com.joelgh.app.commons.showErrorSnackBar
-import com.joelgh.features.rss_management.data.RssDataRepository
-import com.joelgh.features.rss_management.data.local.XmlLocalDataSource
-import com.joelgh.features.rss_management.domain.SaveRssUseCase
+import com.joelgh.app.commons.showSnackBar
 import com.joelgh.features.rss_management.presentation.adapter.RssManagementAdapter
 import com.joelgh.rss_aggregator.NavGraphDirections
 import com.joelgh.rss_aggregator.R
@@ -88,7 +79,7 @@ class RssManagementFragment : Fragment() {
                     rssAdapter.setOnClickItem {
                         viewModel?.deleteRss(it)
                     }
-                    showErrorSnackBar(getString(R.string.generic_error))
+                    showSnackBar(getString(R.string.generic_error))
                 }
             }
         }

--- a/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementFragment.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementFragment.kt
@@ -77,13 +77,8 @@ class RssManagementFragment : Fragment() {
                     }
                     if(it.deleteSuccess)showSnackBar(getString(R.string.delete_success))
                 }else{
-                    rssAdapter.setDataItems(it.rssList!!)
-                    rssAdapter.setOnClickItem {
-                        viewModel?.deleteRss(it)
-                    }
                     when(it.error){
-                        is ErrorApp.DataError -> showSnackBar(getString(R.string.no_rss_found))
-                        is ErrorApp.DeleteError -> showSnackBar(getString(R.string.delete_error))
+                        is ErrorApp.DataError -> showSnackBar(getString(R.string.generic_error))
                     }
                 }
             }

--- a/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementViewModel.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementViewModel.kt
@@ -6,12 +6,14 @@ import androidx.lifecycle.viewModelScope
 import com.joelgh.app.commons.error_management.Either
 import com.joelgh.app.commons.error_management.ErrorApp
 import com.joelgh.app.commons.error_management.left
+import com.joelgh.features.rss_management.domain.DeleteRssUseCase
 import com.joelgh.features.rss_management.domain.GetRssUseCase
 import com.joelgh.features.rss_management.domain.Rss
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-class RssManagementViewModel(private val getRss: GetRssUseCase) : ViewModel(){
+class RssManagementViewModel(private val getRss: GetRssUseCase,
+                             private val deleteRss: DeleteRssUseCase) : ViewModel(){
 
     val rssPublisher: MutableLiveData<UiState> by lazy {
         MutableLiveData<UiState>()
@@ -29,6 +31,18 @@ class RssManagementViewModel(private val getRss: GetRssUseCase) : ViewModel(){
                     UiState(false, null, rss.value)
                 )
             }
+        }
+    }
+
+    fun deleteRss(name: String){
+        viewModelScope.launch(Dispatchers.IO){
+            val result = deleteRss.execute(name)
+            /*when(result){
+                is Either.Left -> rssPublisher.postValue(
+                    UiState(false, result.value)
+                )
+                is Either.Right -> getRss()
+            }*/
         }
     }
 

--- a/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementViewModel.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementViewModel.kt
@@ -19,6 +19,8 @@ class RssManagementViewModel(private val getRss: GetRssUseCase,
         MutableLiveData<UiState>()
     }
 
+    private var rssList: List<Rss>? = null
+
     fun getRss() {
         rssPublisher.value = UiState(true)
         viewModelScope.launch(Dispatchers.IO) {
@@ -27,9 +29,13 @@ class RssManagementViewModel(private val getRss: GetRssUseCase,
                 is Either.Left -> rssPublisher.postValue(
                     UiState(false, rss.value)
                 )
-                is Either.Right -> rssPublisher.postValue(
-                    UiState(false, null, rss.value)
-                )
+                is Either.Right -> {
+                    rssList = rss.value
+                    rssPublisher.postValue(
+                        UiState(false, null, rss.value)
+                    )
+                }
+
             }
         }
     }
@@ -37,18 +43,23 @@ class RssManagementViewModel(private val getRss: GetRssUseCase,
     fun deleteRss(name: String){
         viewModelScope.launch(Dispatchers.IO){
             val result = deleteRss.execute(name)
-            /*when(result){
+            when(result){
                 is Either.Left -> rssPublisher.postValue(
                     UiState(false, result.value)
                 )
-                is Either.Right -> getRss()
-            }*/
+                is Either.Right -> {
+                    rssPublisher.postValue(
+                        UiState(false, null, rssList, true)
+                    )
+                }
+            }
         }
     }
 
     data class UiState(
         val isLoading: Boolean,
         val error: ErrorApp? = null,
-        val rssList: List<Rss> = emptyList()
+        val rssList: List<Rss>? = emptyList(),
+        val deleteSuccess: Boolean = false
     )
 }

--- a/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementViewModel.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/presentation/RssManagementViewModel.kt
@@ -19,8 +19,6 @@ class RssManagementViewModel(private val getRss: GetRssUseCase,
         MutableLiveData<UiState>()
     }
 
-    private var rssList: List<Rss>? = null
-
     fun getRss() {
         rssPublisher.value = UiState(true)
         viewModelScope.launch(Dispatchers.IO) {
@@ -30,7 +28,6 @@ class RssManagementViewModel(private val getRss: GetRssUseCase,
                     UiState(false, rss.value)
                 )
                 is Either.Right -> {
-                    rssList = rss.value
                     rssPublisher.postValue(
                         UiState(false, null, rss.value)
                     )
@@ -49,7 +46,7 @@ class RssManagementViewModel(private val getRss: GetRssUseCase,
                 )
                 is Either.Right -> {
                     rssPublisher.postValue(
-                        UiState(false, null, rssList, true)
+                        UiState(false, null, deleteSuccess = true)
                     )
                 }
             }

--- a/app/src/main/java/com/joelgh/features/rss_management/presentation/adapter/RssManagementAdapter.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/presentation/adapter/RssManagementAdapter.kt
@@ -9,11 +9,16 @@ import com.joelgh.rss_aggregator.R
 class RssManagementAdapter : RecyclerView.Adapter<RssManagementViewHolder>() {
 
     private val dataItems = mutableListOf<Rss>()
+    private var itemClick: ((String) -> Unit)? = null
 
     fun setDataItems(rssList: List<Rss>) {
         dataItems.clear()
         dataItems.addAll(rssList)
         notifyDataSetChanged()
+    }
+
+    fun setOnClickItem(itemClick: ((String) -> Unit)){
+        this.itemClick = itemClick
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RssManagementViewHolder {
@@ -23,7 +28,7 @@ class RssManagementAdapter : RecyclerView.Adapter<RssManagementViewHolder>() {
     }
 
     override fun onBindViewHolder(holder: RssManagementViewHolder, position: Int) {
-        holder.bind(dataItems[position])
+        holder.bind(dataItems[position], itemClick)
     }
 
     override fun getItemCount(): Int = dataItems.size

--- a/app/src/main/java/com/joelgh/features/rss_management/presentation/adapter/RssManagementViewHolder.kt
+++ b/app/src/main/java/com/joelgh/features/rss_management/presentation/adapter/RssManagementViewHolder.kt
@@ -7,11 +7,14 @@ import com.joelgh.rss_aggregator.databinding.ViewItemRssManagementBinding
 
 class RssManagementViewHolder(private val view: View) : RecyclerView.ViewHolder(view) {
 
-    fun bind(rss: Rss){
+    fun bind(rss: Rss, itemClick: ((String) -> Unit)?){
         val binding = ViewItemRssManagementBinding.bind(view)
         binding.apply {
             rssName.text = rss.name
             rssUrl.text = rss.url
+            rssDeleteIc.setOnClickListener {
+                itemClick?.invoke(rss.name)
+            }
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,4 +9,7 @@
     <string name="save_error">Se ha producido un error al guardar el rss</string>
     <string name="save_success">Se ha guardado correctamente</string>
     <string name="generic_error">Se ha producido un error</string>
+    <string name="delete_error">Se ha producido un error al eliminar el rss</string>
+    <string name="delete_success">Se ha eliminado correctamente</string>
+    <string name="no_rss_found">No se ha encontrado ningun rss</string>
 </resources>


### PR DESCRIPTION
## Description de la tarea

<!-- Descripción sobre lo que se pide en la tarea -->

## ¿Cómo se ha implementado?

He creado otra clase para la gestión de errores para distinguir cuando se trata de un error al eliminar o al recuperar.
También elimine una línea de código innecesaria en el formulario y modifique la implementación de la función de extensión de la snackbar.
Para poder usar el mismo UiState que el método getRss cree una variable privada para almacenar la lista de rss. De esta forma puedo pasársela al UiState desde el método eliminar, de otra forma se mostraría la pantalla en blanco porque la lista es una empty list en caso de no pasarle nada y la vista se actualiza para no mostrar nada.

## Keywords

viewmodel, observer, presentation, either

## Screenshots or Video

https://user-images.githubusercontent.com/107778199/204887769-5bd5d69b-c732-4ced-8f17-8ce64bc26003.mp4

## Objetivos

<!-- Buscar en el README el Resultado de Aprendizaje con el que se está trabajando -->

## Criterios de Evaluación
<!-- 
    Buscar en el README los criterios de Evaluación con los que se están trabajando.
    Marca con una [X] los conseguidos. Ejemplo:
    [ ] Criterio Evaluación 1.
    [ ] Criterio Evaluación 2.
    [X] Criterio Evaluación 3.
-->