### PR TITLE
Obtener noticias rss (dominio)

### DIFF
--- a/app/src/main/java/com/joelgh/features/rss_feed/domain/GetRssFeedUseCase.kt
+++ b/app/src/main/java/com/joelgh/features/rss_feed/domain/GetRssFeedUseCase.kt
@@ -1,0 +1,21 @@
+package com.joelgh.features.rss_feed.domain
+
+import com.joelgh.app.commons.error_management.Either
+import com.joelgh.app.commons.error_management.ErrorApp
+import com.joelgh.app.commons.error_management.right
+import com.joelgh.features.rss_management.domain.RssRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class GetRssFeedUseCase(private val rssRepository: RssRepository, private val newsRssRepository: NewsRssRepository) {
+
+    suspend fun execute(): Flow<Either<ErrorApp, List<NewsRssModel>>> {
+        return rssRepository.getAll().map {
+            val news = mutableListOf<NewsRssModel>()
+            it.get().forEach { rss ->
+                news.add(newsRssRepository.getNews(rss.url))
+            }
+            news.right()
+        }
+    }
+}

--- a/app/src/main/java/com/joelgh/features/rss_feed/domain/GetRssFeedUseCase.kt
+++ b/app/src/main/java/com/joelgh/features/rss_feed/domain/GetRssFeedUseCase.kt
@@ -18,4 +18,8 @@ class GetRssFeedUseCase(private val rssRepository: RssRepository, private val ne
             news.right()
         }
     }
+
+    data class NewRss(
+        val title: String
+    )
 }

--- a/app/src/main/java/com/joelgh/features/rss_feed/domain/GetRssFeedUseCase.kt
+++ b/app/src/main/java/com/joelgh/features/rss_feed/domain/GetRssFeedUseCase.kt
@@ -4,22 +4,24 @@ import com.joelgh.app.commons.error_management.Either
 import com.joelgh.app.commons.error_management.ErrorApp
 import com.joelgh.app.commons.error_management.right
 import com.joelgh.features.rss_management.domain.RssRepository
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
 class GetRssFeedUseCase(private val rssRepository: RssRepository, private val newsRssRepository: NewsRssRepository) {
 
-    suspend fun execute(): Flow<Either<ErrorApp, List<NewsRssModel>>> {
-        return rssRepository.getAll().map {
-            val news = mutableListOf<NewsRssModel>()
+    suspend fun execute(): Either<ErrorApp, List<NewsRssModel>> {
+        val news = mutableListOf<NewsRssModel>()
+        rssRepository.getAll().map {
             it.get().forEach { rss ->
                 news.add(newsRssRepository.getNews(rss.url))
             }
-            news.right()
         }
+        return news.right()
     }
 
     data class NewRss(
-        val title: String
+        val title: String,
+        val image: String,
+        val source: String,
+        val description: String
     )
 }

--- a/app/src/main/java/com/joelgh/features/rss_feed/domain/NewsRssModel.kt
+++ b/app/src/main/java/com/joelgh/features/rss_feed/domain/NewsRssModel.kt
@@ -1,0 +1,3 @@
+package com.joelgh.features.rss_feed.domain
+
+data class NewsRssModel(val title: String)

--- a/app/src/main/java/com/joelgh/features/rss_feed/domain/NewsRssModel.kt
+++ b/app/src/main/java/com/joelgh/features/rss_feed/domain/NewsRssModel.kt
@@ -1,3 +1,3 @@
 package com.joelgh.features.rss_feed.domain
 
-data class NewsRssModel(val title: String)
+data class NewsRssModel(val news: List<GetRssFeedUseCase.NewRss>)

--- a/app/src/main/java/com/joelgh/features/rss_feed/domain/NewsRssRepository.kt
+++ b/app/src/main/java/com/joelgh/features/rss_feed/domain/NewsRssRepository.kt
@@ -1,0 +1,5 @@
+package com.joelgh.features.rss_feed.domain
+
+interface NewsRssRepository {
+    suspend fun getNews(url: String): NewsRssModel
+}


### PR DESCRIPTION
## Description de la tarea

Issue: #24 
Crear caso de uso, modelos y repositorio necesarios para obtener noticias de los rss

## ¿Cómo se ha implementado?

El repositorio devuelve un modelo de dominio que contiene un listado de noticias, devuelvo el modelo completo en lugar del listado para que sea igual a la implementación de remoto y así facilitar el mapeo más adelante.
El caso de uso utiliza el repositorio de rss que tenía flow, como no es necesario que está parte de la aplicación sea reactiva he decidido devolver el listado del feed sin flow. De está forma será más sencillo trabajar con los datos y no se ve afectado el funcionamiento.

## Keywords

use case, repository, models

## Screenshots or Video

<!-- Captura de pantalla de la consola -->

## Objetivos

<!-- Buscar en el README el Resultado de Aprendizaje con el que se está trabajando -->

## Criterios de Evaluación
<!-- 
    Buscar en el README los criterios de Evaluación con los que se están trabajando.
    Marca con una [X] los conseguidos. Ejemplo:
    [ ] Criterio Evaluación 1.
    [ ] Criterio Evaluación 2.
    [X] Criterio Evaluación 3.
-->